### PR TITLE
Make feed rights optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const feed = new Feed({
   language: "en", // optional, used only in RSS 2.0, possible values: http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes
   image: "http://example.com/image.png",
   favicon: "http://example.com/favicon.ico",
-  copyright: "All rights reserved 2013, John Doe",
+  copyright: "All rights reserved 2013, John Doe", // optional
   updated: new Date(2013, 6, 14), // optional, default = today
   generator: "awesome", // optional, default = 'Feed for Node.js'
   feedLinks: {

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -67,7 +67,12 @@ export interface FeedOptions {
   description?: string;
   image?: string;
   favicon?: string;
-  copyright: string;
+  /**
+   * Copyright rights information for the feed
+   *
+   * Optional in Atom feeds and RSS.
+   */
+  copyright?: string;
 }
 
 export interface Extension {


### PR DESCRIPTION
## Summary
- allow optional copyright field in feed options
- document that rights is optional in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685046d0949c83339659447b3c018160